### PR TITLE
[Feature] Transaction update warnings

### DIFF
--- a/src/commands/property/update.ts
+++ b/src/commands/property/update.ts
@@ -1,7 +1,6 @@
 import { Argument, Option } from "commander";
 import { QuestionCollection } from "inquirer";
 import chalk from "chalk";
-import CliTable3 from "cli-table3";
 import { RequestMethod, SuccessResponse } from "../../types";
 import {
   display,
@@ -82,17 +81,6 @@ const promptQuestions: QuestionCollection<PromptAnswers> = [
   },
 ];
 
-const pushUpdateResultRow = (
-  rowTitle: string,
-  table: CliTable3.Table,
-  oldValue: any,
-  newValue: any
-) => {
-  if (oldValue !== newValue) {
-    table.push([rowTitle, oldValue, "->", newValue]);
-  }
-};
-
 const displayUpdateResult = (response: SuccessResponse) => {
   const payload = response.data.payload;
   const oldProperty = payload.updatedFrom;
@@ -102,17 +90,27 @@ const displayUpdateResult = (response: SuccessResponse) => {
   console.log(chalk.cyan(chalk.bold(`Property ID ${oldProperty.id}`)));
 
   const table = display.table.createCompact();
-  pushUpdateResultRow("Name:", table, oldProperty.name, newProperty.name);
-  pushUpdateResultRow(
-    "Description:",
+  display.table.pushValueUpdateRow(
     table,
+    "Name",
+    oldProperty.name,
+    newProperty.name
+  );
+  display.table.pushValueUpdateRow(
+    table,
+    "Description",
     oldProperty.description,
     newProperty.description
   );
-  pushUpdateResultRow("Amount:", table, oldProperty.amount, newProperty.amount);
-  pushUpdateResultRow(
-    "In stock:",
+  display.table.pushValueUpdateRow(
     table,
+    "Amount",
+    oldProperty.amount,
+    newProperty.amount
+  );
+  display.table.pushValueUpdateRow(
+    table,
+    "In stock",
     oldProperty.amountInStock,
     newProperty.amountInStock
   );

--- a/src/commands/transaction/update.ts
+++ b/src/commands/transaction/update.ts
@@ -64,7 +64,7 @@ const promptQuestions: QuestionCollection<PromptAnswers> = [
  * the value change from `oldValue` to `newValue`. If `oldValue` is equal to
  * `newValue`, print a warning to the console.
  */
-const pushUpdateResultRow = (
+const pushUpdateOrWarn = (
   rowTitle: string,
   table: CliTable3.Table,
   oldValue: any,
@@ -86,13 +86,8 @@ const displayUpdateResult = (response: SuccessResponse) => {
   const newTransaction = payload.transaction;
 
   const table = display.table.createCompact();
-  pushUpdateResultRow(
-    "Title",
-    table,
-    oldTransaction.title,
-    newTransaction.title
-  );
-  pushUpdateResultRow(
+  pushUpdateOrWarn("Title", table, oldTransaction.title, newTransaction.title);
+  pushUpdateOrWarn(
     "Change in amount",
     table,
     oldTransaction.amountChange,

--- a/src/commands/transaction/update.ts
+++ b/src/commands/transaction/update.ts
@@ -59,6 +59,11 @@ const promptQuestions: QuestionCollection<PromptAnswers> = [
   },
 ];
 
+/**
+ * Push one row of update result to `table` with row title `rowTitle` and show
+ * the value change from `oldValue` to `newValue`. If `oldValue` is equal to
+ * `newValue`, print a warning to the console.
+ */
 const pushUpdateResultRow = (
   rowTitle: string,
   table: CliTable3.Table,
@@ -66,7 +71,13 @@ const pushUpdateResultRow = (
   newValue: any
 ) => {
   if (oldValue !== newValue) {
-    table.push([rowTitle, oldValue, "->", newValue]);
+    table.push([`${rowTitle}:`, oldValue, "->", newValue]);
+  } else {
+    // Warning proposed by Evence in https://github.com/lanyanxiang/habits-cli/pull/67.
+    console.warn(
+      `${chalk.bgYellow("WARN")} "${rowTitle}" was not updated ` +
+        `because its current value is equal to the value entered (value: ${oldValue}).`
+    );
   }
 };
 
@@ -80,13 +91,13 @@ const displayUpdateResult = (response: SuccessResponse) => {
 
   const table = display.table.createCompact();
   pushUpdateResultRow(
-    "Title:",
+    "Title",
     table,
     oldTransaction.title,
     newTransaction.title
   );
   pushUpdateResultRow(
-    "Change in amount:",
+    "Change in amount",
     table,
     oldTransaction.amountChange,
     newTransaction.amountChange

--- a/src/commands/transaction/update.ts
+++ b/src/commands/transaction/update.ts
@@ -75,8 +75,7 @@ const pushUpdateResultRow = (
   } else {
     // Warning proposed by Evence in https://github.com/lanyanxiang/habits-cli/pull/67.
     console.warn(
-      `${chalk.bgYellow("WARN")} "${rowTitle}" was not updated ` +
-        `because its current value is equal to the value entered (value: ${oldValue}).`
+      `${chalk.bgYellow("WARN")} "${rowTitle}" already has value ${oldValue}.`
     );
   }
 };
@@ -85,9 +84,6 @@ const displayUpdateResult = (response: SuccessResponse) => {
   const payload = response.data.payload;
   const oldTransaction = payload.updatedFrom;
   const newTransaction = payload.transaction;
-
-  console.log();
-  console.log(chalk.cyan(chalk.bold(`Transaction ID ${oldTransaction.id}`)));
 
   const table = display.table.createCompact();
   pushUpdateResultRow(
@@ -102,6 +98,9 @@ const displayUpdateResult = (response: SuccessResponse) => {
     oldTransaction.amountChange,
     newTransaction.amountChange
   );
+
+  console.log();
+  console.log(chalk.cyan(chalk.bold(`Transaction ID ${oldTransaction.id}`)));
   if (!table.length) {
     console.log(chalk.bold("No changes applied."));
   }

--- a/src/commands/transaction/update.ts
+++ b/src/commands/transaction/update.ts
@@ -3,7 +3,6 @@ import { QuestionCollection } from "inquirer";
 import { QuestionCommand, RuntimeError } from "../../models";
 import { display, mainApi, network, validation, vschema } from "../../services";
 import { RequestMethod, SuccessResponse } from "../../types";
-import CliTable3 from "cli-table3";
 import chalk from "chalk";
 import { objectParser } from "../../utils";
 
@@ -59,37 +58,21 @@ const promptQuestions: QuestionCollection<PromptAnswers> = [
   },
 ];
 
-/**
- * Push one row of update result to `table` with row title `rowTitle` and show
- * the value change from `oldValue` to `newValue`. If `oldValue` is equal to
- * `newValue`, print a warning to the console.
- */
-const pushUpdateOrWarn = (
-  rowTitle: string,
-  table: CliTable3.Table,
-  oldValue: any,
-  newValue: any
-) => {
-  if (oldValue !== newValue) {
-    table.push([`${rowTitle}:`, oldValue, "->", newValue]);
-  } else {
-    // Warning proposed by Evence in https://github.com/lanyanxiang/habits-cli/pull/67.
-    console.warn(
-      `${chalk.bgYellow("WARN")} "${rowTitle}" already has value ${oldValue}.`
-    );
-  }
-};
-
 const displayUpdateResult = (response: SuccessResponse) => {
   const payload = response.data.payload;
   const oldTransaction = payload.updatedFrom;
   const newTransaction = payload.transaction;
 
   const table = display.table.createCompact();
-  pushUpdateOrWarn("Title", table, oldTransaction.title, newTransaction.title);
-  pushUpdateOrWarn(
-    "Change in amount",
+  display.table.pushValueUpdateRow(
     table,
+    "Title",
+    oldTransaction.title,
+    newTransaction.title
+  );
+  display.table.pushValueUpdateRow(
+    table,
+    "Change in amount",
     oldTransaction.amountChange,
     newTransaction.amountChange
   );

--- a/src/services/display/table.ts
+++ b/src/services/display/table.ts
@@ -4,6 +4,7 @@
 
 import Table from "cli-table3";
 import chalk from "chalk";
+import { ValueUpdateRowOptions } from "../../types/display";
 
 const create = (options?: Partial<Table.TableConstructorOptions>) => {
   return new Table({
@@ -36,22 +37,23 @@ const createCompact = (options?: Partial<Table.TableConstructorOptions>) => {
   });
 };
 
-interface PushValueUpdateRowOptions {
-  disableEqValueWarning: boolean;
-  shouldIncludeEqValue: boolean;
-}
-
 /**
- * Push one row of value update result to `table` with row title `rowTitle` and
- * show the value change from `oldValue` to `newValue`. If `oldValue` is equal
- * to `newValue`, print a warning to the console.
+ * Push a standard value-update row to `table`. A value-update row indicates
+ * to the user on how the value of a field changes.
+ *
+ * @param table The table to work with.
+ * @param rowTitle The title of the value-update row. This is usually set to
+ *  the specific field being updated.
+ * @param oldValue Old value of the field.
+ * @param newValue New value of the field.
+ * @param options
  */
 const pushValueUpdateRow = (
   table: Table.Table,
   rowTitle: string,
   oldValue: any,
   newValue: any,
-  options?: Partial<PushValueUpdateRowOptions>
+  options?: Partial<ValueUpdateRowOptions>
 ) => {
   if (oldValue === newValue && !options?.disableEqValueWarning) {
     console.warn(

--- a/src/services/display/table.ts
+++ b/src/services/display/table.ts
@@ -4,7 +4,7 @@
 
 import Table from "cli-table3";
 import chalk from "chalk";
-import { ValueUpdateRowOptions } from "../../types/display";
+import { ValueUpdateRowOptions } from "../../types";
 
 const create = (options?: Partial<Table.TableConstructorOptions>) => {
   return new Table({

--- a/src/services/display/table.ts
+++ b/src/services/display/table.ts
@@ -3,6 +3,7 @@
  */
 
 import Table from "cli-table3";
+import chalk from "chalk";
 
 const create = (options?: Partial<Table.TableConstructorOptions>) => {
   return new Table({
@@ -35,8 +36,35 @@ const createCompact = (options?: Partial<Table.TableConstructorOptions>) => {
   });
 };
 
+interface PushValueUpdateRowOptions {
+  disableEqValueWarning: boolean;
+  shouldIncludeEqValue: boolean;
+}
+
+/**
+ * Push one row of value update result to `table` with row title `rowTitle` and
+ * show the value change from `oldValue` to `newValue`. If `oldValue` is equal
+ * to `newValue`, print a warning to the console.
+ */
+const pushValueUpdateRow = (
+  table: Table.Table,
+  rowTitle: string,
+  oldValue: any,
+  newValue: any,
+  options?: Partial<PushValueUpdateRowOptions>
+) => {
+  if (oldValue === newValue && !options?.disableEqValueWarning) {
+    console.warn(
+      `${chalk.bgYellow("WARN")} "${rowTitle}" already has value ${oldValue}.`
+    );
+  }
+  if (oldValue !== newValue || options?.shouldIncludeEqValue) {
+    table.push([`${rowTitle}:`, oldValue, "->", newValue]);
+  }
+};
+
 const print = (table: Table.Table) => {
   console.log(table.toString());
 };
 
-export const table = { create, createCompact, print };
+export const table = { create, createCompact, pushValueUpdateRow, print };

--- a/src/types/display/index.ts
+++ b/src/types/display/index.ts
@@ -1,0 +1,1 @@
+export * from "./table";

--- a/src/types/display/table.ts
+++ b/src/types/display/table.ts
@@ -1,0 +1,12 @@
+export interface ValueUpdateRowOptions {
+  /**
+   * When set to true, no warning message will be printed on the console
+   * if the old value is equal to the new value. Defaults to false.
+   */
+  disableEqValueWarning: boolean;
+  /**
+   * When set to true, a row will still be added to the table when the old
+   * value is equal to the new value. Defaults to false.
+   */
+  shouldIncludeEqValue: boolean;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,4 +3,5 @@ export * from "./spinners";
 export * from "./commander";
 export * from "./secrets";
 export * from "./api";
+export * from "./display";
 export * from "./config";


### PR DESCRIPTION
In this pull request:
* When a transaction/property is being updated, show warnings for the fields when their `oldValue` is equal to `newValue`.
* Extract table helper function `pushValueUpdateRow` that pushes a row to indicate a value update into the table.
* Update the logging order for the update methods.

This pull request closes https://github.com/lanyanxiang/habits-cli/issues/52. We switched from blocking the entire update to showing warning messages due to user feedback. Thanks @evencewang for providing this feedback, I appreciate that!

@evencewang Please review this pull request and tell me if this solution looks good.